### PR TITLE
Returning location in more cases, build improvements and fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,20 +2,16 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
-    exec_jshint: {
+    jshint: {
       all: ['Gruntfile.js', 'src/**/*.js', 'test/**/*.js']
     },
 
-    mocha_debug: {
+    mochaTest: {
       options: {
-        reporter: 'dot',
-        check: ['src/**/*.js', 'test/**/*.js']
+        reporter: 'spec',
+        ui: 'tdd'
       },
-      nodejs: {
-        options: {
-          src: ['src/**/*.js', 'test/**/*.js']
-        }
-      }
+      nodejs: ['src/**/*.js', 'test/**/*.js']
     },
 
     watch: {
@@ -30,12 +26,12 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-exec-jshint');
-  grunt.loadNpmTasks('grunt-mocha-debug');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-newer');
   grunt.loadNpmTasks('grunt-release');
 
-  grunt.registerTask('test', ['newer:exec_jshint', 'mocha_debug']);
-  grunt.registerTask('publish', ['mocha_debug', 'release']);
+  grunt.registerTask('test', ['newer:jshint', 'mochaTest']);
+  grunt.registerTask('publish', ['mochaTest', 'release']);
   grunt.registerTask('default', ['test', 'watch']);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sourcemap-to-ast",
   "description": "Updates a mozilla AST(produced by acorn/esprima) with location info from a source map",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "homepage": "https://github.com/tarruda/sourcemap-to-ast",
   "author": {
     "name": "Thiago de Arruda",

--- a/package.json
+++ b/package.json
@@ -21,22 +21,25 @@
     }
   ],
   "main": "./src/index",
+  "scripts": {
+    "test": "grunt test"
+  },
   "devDependencies": {
-    "chai": "~1.7.2",
-    "grunt": "~0.4.1",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-mocha-debug": "~0.0.6",
-    "grunt-newer": "~0.5.4",
-    "grunt-exec-jshint": "~0.0.0",
-    "grunt-release": "~0.5.1",
-    "acorn": "~0.3.1",
-    "coffee-script": "~1.6.3"
+    "chai": "~1.9.1",
+    "grunt": "~0.4.4",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.10.2",
+    "grunt-newer": "~0.7.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-release": "~0.7.0",
+    "acorn": "~0.5.0",
+    "coffee-script": "1.6.3"
   },
   "engines": {
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "source-map": "~0.1.30",
-    "estraverse": "~1.3.1"
+    "source-map": "~0.1.33",
+    "estraverse": "~1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sourcemap-to-ast",
   "description": "Updates a mozilla AST(produced by acorn/esprima) with location info from a source map",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/tarruda/sourcemap-to-ast",
   "author": {
     "name": "Thiago de Arruda",
@@ -33,7 +33,7 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-release": "~0.7.0",
     "acorn": "~0.5.0",
-    "coffee-script": "1.6.3"
+    "coffee-script": "1.7.1"
   },
   "engines": {
     "node": ">= 0.8.0"

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,16 @@ module.exports = function sourceMapToAst(ast, map) {
       if (!(node.type && node.loc)) return;
 
       var origStart = map.originalPositionFor(node.loc.start);
-      var origEnd = map.originalPositionFor(node.loc.end);
 
-      if (!(origStart.line && origEnd.line)) {
+      if (!origStart.line) {
         delete node.loc;
         return;
+      }
+
+      var origEnd = map.originalPositionFor(node.loc.end);
+
+      if (origEnd.line && ((origEnd.line < origStart.line) || (origEnd.column < origStart.column))) {
+        origEnd.line = null;
       }
 
       node.loc = {
@@ -22,7 +27,7 @@ module.exports = function sourceMapToAst(ast, map) {
           line: origStart.line,
           column: origStart.column
         },
-        end: {
+        end: origEnd.line && {
           line: origEnd.line,
           column: origEnd.column
         },

--- a/test/index.js
+++ b/test/index.js
@@ -1,38 +1,32 @@
 var acorn = require('acorn');
 var coffee = require('coffee-script');
-
-var sourceMapToAst = require('../src');
-
+var expect = require('chai').expect;
+var sourceMapToAst = require('..');
 
 global.expect = require('chai').expect;
 
+test('test', function () {
+  var compiled = coffee.compile('x =\n 1', {sourceMap: true});
+  var ast = acorn.parse(compiled.js, {locations: true});
 
-run({
-  'Suite': {
-    'test': function() {
-      var compiled = coffee.compile('x =\n 1', {sourceMap: true});
-      var ast = acorn.parse(compiled.js, {locations: true});
+  expect(compiled.js).to.eql(
+    '(function() {\n' +
+    '  var x;\n\n' +
 
-      expect(compiled.js).to.eql(
-        '(function() {\n' +
-        '  var x;\n\n' +
+    '  x = 1;\n\n' + // line 4 and columns 2 to 7
 
-        '  x = 1;\n\n' + // line 4 and columns 2 to 7
+    '}).call(this);\n'
+  );
 
-        '}).call(this);\n'
-      );
+  var func = ast.body[0].expression.callee.object;
+  var funcBody = func.body.body;
+  var assignment = funcBody[1].expression;
 
-      var func = ast.body[0].expression.callee.object;
-      var funcBody = func.body.body;
-      var assignment = funcBody[1].expression;
+  expect(assignment.loc.start).to.eql({line: 4, column: 2});
+  expect(assignment.loc.end).to.eql({line: 4, column: 7});
 
-      expect(assignment.loc.start).to.eql({line: 4, column: 2});
-      expect(assignment.loc.end).to.eql({line: 4, column: 7});
+  sourceMapToAst(ast, compiled.v3SourceMap);
 
-      sourceMapToAst(ast, compiled.v3SourceMap);
-
-      expect(assignment.loc.start).to.eql({line: 1, column: 0});
-      expect(assignment.loc.end).to.eql({line: 2, column: 1});
-    }
-  }
+  expect(assignment.loc.start).to.eql({line: 1, column: 0});
+  expect(assignment.loc.end).to.eql({line: 2, column: 1});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -28,5 +28,5 @@ test('test', function () {
   sourceMapToAst(ast, compiled.v3SourceMap);
 
   expect(assignment.loc.start).to.eql({line: 1, column: 0});
-  expect(assignment.loc.end).to.eql({line: 2, column: 1});
+  expect(assignment.right.loc.start).to.eql({line: 2, column: 1});
 });


### PR DESCRIPTION
Returning location even when only `start` is available, fixed tests (new CoffeeScript doesn't map `end` positions but only `start`), improved build to be cross-platform (running on Windows now).
